### PR TITLE
#51: Implemented cppcheck static analyser for lint analysis

### DIFF
--- a/.github/workflows/master-workflow.yml
+++ b/.github/workflows/master-workflow.yml
@@ -26,17 +26,29 @@ jobs:
       id: make
       run: make all
 
+    - name: Lint
+      id: lint
+      run: make lint
+
     - name: Doxygen Action
       id: doxygen_action
       uses: mattnotmitt/doxygen-action@v1.3.1
       with:
         doxyfile-path: 'ttt_doxy'
 
-    - name: Easy Zip Files
+    - name: Easy Zip Files Documentation
+      id: easy_zip_files_documentation
       uses: vimtor/action-zip@v1
       with:
           files: Documentation/ 
           dest: Documentation.zip
+
+    - name: Easy Zip Files Lint
+      id: easy_zip_files_lint
+      uses: vimtor/action-zip@v1
+      with:
+          files: lintresult/ 
+          dest: lintresult.zip
 
     - name: Consolidate
       run: | 
@@ -45,6 +57,7 @@ jobs:
         mv bin/build_linux/tictactoe.out Release/tictactoe.out
         mv bin/build_windows/tictactoe.exe Release/tictactoe.exe
         mv Documentation.zip Release/Documentation.zip
+        mv lintresult.zip Release/lintresult.zip
 
 
     - name: Create Release
@@ -89,4 +102,15 @@ jobs:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: Release/Documentation.zip
         asset_name: Documentation.zip
+        asset_content_type: documentation
+
+    - name: Upload Asset Lint Results
+      id: upload-release-asset-lint
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: Release/lintresult.zip
+        asset_name: lintresult.zip
         asset_content_type: documentation

--- a/.github/workflows/master-workflow.yml
+++ b/.github/workflows/master-workflow.yml
@@ -42,8 +42,8 @@ jobs:
       run: | 
       
         mkdir Release
-        mv build_linux/tictactoe.out Release/tictactoe.out
-        mv build_windows/tictactoe.exe Release/tictactoe.exe
+        mv bin/build_linux/tictactoe.out Release/tictactoe.out
+        mv bin/build_windows/tictactoe.exe Release/tictactoe.exe
         mv Documentation.zip Release/Documentation.zip
 
 

--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -30,14 +30,14 @@ jobs:
         uses: actions/upload-artifact@v2
         with: 
           name: Linux_Binary
-          path: build_linux/tictactoe.out
+          path: bin/build_linux/tictactoe.out
 
       - name: Upload Windows EXE
         id: upload_windows_exe
         uses: actions/upload-artifact@v2
         with:
           name: Windows_EXE
-          path: build_windows/tictactoe.exe
+          path: bin/build_windows/tictactoe.exe
 
   test_on_ubuntu:
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # ignore the following for git repos
 
+.vs/
 .vscode/
 build_linux/
 build_windows/
 Documentation/
+lintresults/

--- a/lint.mk
+++ b/lint.mk
@@ -1,0 +1,19 @@
+# linting oh linting...
+
+LINT_BIN := cppcheck
+LINT_DIR := ./lintresults
+LINT_SUFFIX := cppcheck-lint
+
+SRC_DIRS ?= $(shell pwd)
+SRCS ?= $(shell find $(SRC_DIRS) -type f -name "*.cpp")
+
+$(LINT_DIR):
+	$(MKDIR_P) $(LINT_DIR)
+	for src_file in $(SRCS); do \
+		echo $$src_file; \
+		$(LINT_BIN) --enable=all --language=c++ --template=vs -I $(SRC_DIRS) $$src_file 2> $(LINT_DIR)/$$(basename $$src_file).$(LINT_SUFFIX); \
+	done
+	
+	@echo Linting completed successfully!
+
+MKDIR_P ?= mkdir -p

--- a/linux.mk
+++ b/linux.mk
@@ -1,6 +1,6 @@
 TARGET_EXEC_LINUX ?= tictactoe.out
 
-BUILD_DIR_LINUX ?= ./build_linux
+BUILD_DIR_LINUX ?= ./bin/build_linux
 SRC_DIRS ?= $(shell pwd)
 
 SRCS := $(shell find $(SRC_DIRS) -type f -name "*.cpp")
@@ -34,6 +34,7 @@ $(BUILD_DIR_LINUX)/%.s.o: %.s
 $(BUILD_DIR_LINUX)/$(TARGET_EXEC_LINUX): $(OBJS_LINUX)
 	$(LCPP) $(OBJS_LINUX) -o $@ $(LDFLAGS) $(LIBS)
 
+@echo Linux build completed successfully!
 
 -include $(DEPS)
 

--- a/linux.mk
+++ b/linux.mk
@@ -11,6 +11,7 @@ INC_DIRS := $(shell find $(SRC_DIRS) -type d)
 INC_FLAGS := $(addprefix -I,$(INC_DIRS))
 
 CPPFLAGS ?= $(INC_FLAGS) -MMD -MP
+OPTIMIZATION := -O3
 
 # Linux Compiler
 LCPP = g++ 
@@ -24,7 +25,7 @@ LIBS = -static-libgcc -static-libstdc++
 # linux
 $(BUILD_DIR_LINUX)/%.cpp.o: %.cpp
 	$(MKDIR_P) $(dir $@)
-	$(LCPP) $(COMPILE_FLAGS) $(LIBS) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
+	$(LCPP) $(COMPILE_FLAGS) $(LIBS) $(CPPFLAGS) $(OPTIMIZATION) $(CXXFLAGS) -c $< -o $@
 
 $(BUILD_DIR_LINUX)/%.s.o: %.s
 	$(MKDIR_P) $(dir $@)
@@ -34,7 +35,7 @@ $(BUILD_DIR_LINUX)/%.s.o: %.s
 $(BUILD_DIR_LINUX)/$(TARGET_EXEC_LINUX): $(OBJS_LINUX)
 	$(LCPP) $(OBJS_LINUX) -o $@ $(LDFLAGS) $(LIBS)
 
-@echo Linux build completed successfully!
+	@echo Linux build completed successfully!
 
 -include $(DEPS)
 

--- a/makefile
+++ b/makefile
@@ -1,5 +1,11 @@
-BUILD_DIR_LINUX ?= ./build_linux
-BUILD_DIR_WINDOWS ?= ./build_windows
+BUILD_DIR := ./bin
+BUILD_DIR_LINUX ?= $(BUILD_DIR)/build_linux
+BUILD_DIR_WINDOWS ?= $(BUILD_DIR)/build_windows
+
+DOXYGEN := doxygen
+DOXYGEN_DIR := Documentation
+
+LINT_DIR := lintresults
 
 all: 
 	$(MAKE) -f linux.mk
@@ -11,9 +17,22 @@ linux:
 windows:
 	$(MAKE) -f windows.mk
 
+lint:
+	$(MAKE) -f lint.mk
 
+doc:
+	$(DOXYGEN) ttt_doxy
+	
 .PHONY: clean
 
 clean:
-	$(RM) -r $(BUILD_DIR_LINUX)
-	$(RM) -r $(BUILD_DIR_WINDOWS)
+	$(RM) -r $(BUILD_DIR)
+
+cleanlint:
+	$(RM) -r $(LINT_DIR)
+
+cleandoc:
+	$(RM) -r $(DOXYGEN_DIR)
+
+help:
+	@echo use "make [all|linux|windows|lint|doc|clean|help]" 

--- a/makefile
+++ b/makefile
@@ -35,4 +35,4 @@ cleandoc:
 	$(RM) -r $(DOXYGEN_DIR)
 
 help:
-	@echo use "make [all|linux|windows|lint|doc|clean|help]" 
+	@echo use "make [all|linux|windows|lint|doc|clean|cleanlint|cleandoc|help]" 

--- a/windows.mk
+++ b/windows.mk
@@ -11,6 +11,7 @@ INC_DIRS := $(shell find $(SRC_DIRS) -type d)
 INC_FLAGS := $(addprefix -I,$(INC_DIRS))
 
 CPPFLAGS ?= $(INC_FLAGS) -MMD -MP
+OPTIMIZATION := -O3
 
 
 # Windows Cross Compiler
@@ -26,7 +27,7 @@ LIBS = -static-libgcc -static-libstdc++
 # windows
 $(BUILD_DIR_WINDOWS)/%.cpp.o: %.cpp
 	$(MKDIR_P) $(dir $@)
-	$(WINCPP) $(COMPILE_FLAGS) $(LIBS) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
+	$(WINCPP) $(COMPILE_FLAGS) $(LIBS) $(CPPFLAGS) $(OPTIMIZATION) $(CXXFLAGS) -c $< -o $@
 
 $(BUILD_DIR_WINDOWS)/%.s.o: %.s
 	$(MKDIR_P) $(dir $@)
@@ -35,7 +36,7 @@ $(BUILD_DIR_WINDOWS)/%.s.o: %.s
 $(BUILD_DIR_WINDOWS)/$(TARGET_EXEC_WINDOWS): $(OBJS_WINDOWS)
 	$(WINCPP) $(OBJS_WINDOWS) -o $@ $(LDFLAGS) $(LIBS)
 
-@echo Windows build completed successfully!
+	@echo Windows build completed successfully!
 
 -include $(DEPS)
 

--- a/windows.mk
+++ b/windows.mk
@@ -1,6 +1,6 @@
 TARGET_EXEC_WINDOWS ?= tictactoe.exe
 
-BUILD_DIR_WINDOWS ?= ./build_windows
+BUILD_DIR_WINDOWS ?= ./bin/build_windows
 SRC_DIRS ?= $(shell pwd)
 
 SRCS := $(shell find $(SRC_DIRS) -type f -name "*.cpp")
@@ -34,6 +34,8 @@ $(BUILD_DIR_WINDOWS)/%.s.o: %.s
 
 $(BUILD_DIR_WINDOWS)/$(TARGET_EXEC_WINDOWS): $(OBJS_WINDOWS)
 	$(WINCPP) $(OBJS_WINDOWS) -o $@ $(LDFLAGS) $(LIBS)
+
+@echo Windows build completed successfully!
 
 -include $(DEPS)
 


### PR DESCRIPTION
Implemented #51 ,

1. cppcheck static analyser
2. Added lint.mk for lint support via make rules
3. Modified makefiles to accommodate lint integration 